### PR TITLE
Add page templates

### DIFF
--- a/components/index.js
+++ b/components/index.js
@@ -1,0 +1,2 @@
+export { default as Page } from './page'
+export { default as Nav } from './nav'

--- a/components/nav.js
+++ b/components/nav.js
@@ -2,8 +2,10 @@ import React from 'react'
 import Link from 'next/link'
 
 const links = [
-  { href: 'https://zeit.co/now', label: 'ZEIT' },
-  { href: 'https://github.com/zeit/next.js', label: 'GitHub' }
+  { href: '/', label: 'Home' },
+  { href: '/about', label: 'About' },
+  { href: '/skills', label: 'Skills' },
+  { href: '/works', label: 'Works' }
 ].map(link => {
   link.key = `nav-link-${link.href}-${link.label}`
   return link
@@ -12,44 +14,14 @@ const links = [
 const Nav = () => (
   <nav>
     <ul>
-      <li>
-        <Link href='/'>
-          <a>Home</a>
-        </Link>
-      </li>
       {links.map(({ key, href, label }) => (
         <li key={key}>
-          <a href={href}>{label}</a>
+          <Link href={href} prefetch>
+            {label}
+          </Link>
         </li>
       ))}
     </ul>
-
-    <style jsx>{`
-      :global(body) {
-        margin: 0;
-        font-family: -apple-system, BlinkMacSystemFont, Avenir Next, Avenir,
-          Helvetica, sans-serif;
-      }
-      nav {
-        text-align: center;
-      }
-      ul {
-        display: flex;
-        justify-content: space-between;
-      }
-      nav > ul {
-        padding: 4px 16px;
-      }
-      li {
-        display: flex;
-        padding: 6px 8px;
-      }
-      a {
-        color: #067df7;
-        text-decoration: none;
-        font-size: 13px;
-      }
-    `}</style>
   </nav>
 )
 

--- a/components/page.js
+++ b/components/page.js
@@ -1,0 +1,11 @@
+import { Head } from 'next/head'
+import { Nav } from '.'
+
+const Page = ({ children }) => (
+  <div>
+    <Nav />
+    {children}
+  </div>
+)
+
+export default Page

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -26,6 +26,7 @@ export default class MyDocument extends Document {
         <Head>
           {/* Step 5: Output the styles in the head  */}
           {this.props.styleTags}
+          <link rel="icon" href="/favicon.ico" />
         </Head>
         <body>
           <Main />

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,0 +1,9 @@
+import { Page } from '../components'
+
+const About = () => (
+  <Page>
+    <h1>About</h1>
+  </Page>
+)
+
+export default About

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,16 +1,8 @@
 import React from 'react'
-import Head from 'next/head'
-import Nav from '../components/nav'
+import { Page } from '../components'
 
 const Home = () => (
-  <div>
-    <Head>
-      <title>Home</title>
-      <link rel="icon" href="/favicon.ico" />
-    </Head>
-
-    <Nav />
-
+  <Page>
     <div className="hero">
       <h1 className="title">Welcome to Next.js!</h1>
       <p className="description">
@@ -35,7 +27,7 @@ const Home = () => (
         </a>
       </div>
     </div>
-  </div>
+  </Page>
 )
 
 export default Home

--- a/pages/skills.js
+++ b/pages/skills.js
@@ -1,0 +1,9 @@
+import { Page } from '../components'
+
+const Skills = () => (
+  <Page>
+    <h1>Skills</h1>
+  </Page>
+)
+
+export default Skills

--- a/pages/works.js
+++ b/pages/works.js
@@ -1,0 +1,9 @@
+import { Page } from '../components'
+
+const Works = () => (
+  <Page>
+    <h1>Works</h1>
+  </Page>
+)
+
+export default Works


### PR DESCRIPTION
Adds fpo page templates for `about`, `/skills`, and `/works`
Also adds a page wrapper component to make site-wide components always available.
